### PR TITLE
Remove auxiliary definition from emitter

### DIFF
--- a/lib/merlin_recovery.ml
+++ b/lib/merlin_recovery.ml
@@ -119,7 +119,7 @@ module type RECOVERY =
 
 module Make
     (Parser   : MenhirLib.IncrementalEngine.EVERYTHING)
-    (Recovery : RECOVERY with module I = Parser)
+    (Recovery : RECOVERY with module I := Parser)
     (Printer  : PRINTER with module I = Parser) =
 struct
 

--- a/lib/merlin_recovery.mli
+++ b/lib/merlin_recovery.mli
@@ -87,7 +87,7 @@ module type RECOVERY =
 
 module Make
     (Parser   : MenhirLib.IncrementalEngine.EVERYTHING)
-    (Recovery : RECOVERY with module I = Parser)
+    (Recovery : RECOVERY with module I := Parser)
     (Printer  : PRINTER with module I = Parser) :
 sig
 

--- a/menhir-recover/emitter.ml
+++ b/menhir-recover/emitter.ml
@@ -183,8 +183,7 @@ end = struct
     fprintf ppf "let default_value = Default.value\n\n"
 
   let emit_defs ppf =
-    fprintf ppf "module I = %s\n\n" menhir;
-    fprintf ppf "open I\n\n";
+    fprintf ppf "open %s\n\n" menhir;
     fprintf ppf "type action =\n\
                 \  | Abort\n\
                 \  | R of int\n\


### PR DESCRIPTION
Problem: in the #PR4 we add module `I` to fit signature of `RECOVERY_GENERATED`
where `I` is abstract module.

Solution: we can avoid it by using destructive substitutions.