### PR TITLE
[LIGO-329] Fix bug in emitter that generates extra `Sub`

### DIFF
--- a/menhir-recover/emitter.ml
+++ b/menhir-recover/emitter.ml
@@ -252,11 +252,16 @@ in
       | C.IReduce prod -> fprintf ppf "R %d" (Production.to_int prod)
       | C.IShift (T t) -> fprintf ppf "S (T T_%s)" (Terminal.name t)
       | C.IShift (N n) -> fprintf ppf "S (N N_%s)" (Nonterminal.mangled_name n)
-      | C.IRef r -> fprintf ppf "r%d" r
+      | C.IRef r -> fprintf ppf "Sub (r%d)" r
     in
-    let emit_instrs ppf = Utils.pp_list emit_instr ppf in
+    let rec emit_instrs ppf = function
+      | [] -> fprintf ppf "[]"
+      | [C.IRef r] -> fprintf ppf "r%d" r
+      | [instr] -> fprintf ppf "[%a]" emit_instr instr
+      | instr :: instrs -> fprintf ppf "%a :: %a" emit_instr instr emit_instrs instrs
+    in
     let emit_shared index instrs =
-      fprintf ppf "  let r%d = Sub %a in\n" index emit_instrs instrs
+      fprintf ppf "  let r%d = %a in\n" index emit_instrs instrs
     in
     List.iteri emit_shared globals;
     let emit_item ppf item = emit_instrs ppf (get_instr item) in
@@ -267,7 +272,7 @@ in
         fprintf ppf "-> ";
         match cases with
         | `Nothing -> fprintf ppf "Nothing\n";
-        | `One item -> fprintf ppf "One %a\n" emit_item item
+        | `One item -> fprintf ppf "One (%a)\n" emit_item item
         | `Select xs ->
           fprintf ppf "Select (function\n";
           if safe then (


### PR DESCRIPTION
Problem:
There is a difference between Merlin and ocaml-recovery-parser in the
 emitter.ml which leads to poor results on some tests.

Explanation:
There is a `Sub` action that forces the error-recovery algorithm to
apply all recovery steps at once without trying to recover in the
middle of it. The difference is that ocaml-recovery-parser uses `Sub`
more often than Merlin. Here is the example.
The test is missing the `with` keyword.
`MATCH expr . WITH ...`

ocaml-recovery-parser
```
...
let r60 = Sub [S (T T_With); r59] in
...
| 652 -> One [r60]
...
```
Merlin
```
...
let r371 = S (T T_WITH) :: r370 in
...
| 1147 -> One (r371)
...
```
This patch
```
...
let r60 = S (T T_With) :: r59 in
...
| 652 -> One (r60)
...
```
As you can see, the recovery algorithm able to shift `with` and
finish recovery only in the last two cases while in the first
case algorithm have to apply all recovery steps which lead to poor
results on this test

Solution:
Change emitter.ml corresponding to Merlin's