### PR TITLE
[LIGO-355] Make indentation heuristic optional

### DIFF
--- a/lib/merlin_recovery.mli
+++ b/lib/merlin_recovery.mli
@@ -83,6 +83,8 @@ module type RECOVERY =
     (* Customization that slightly affects on internal heuristics of choosing recovery ways.
        But returning [false] always also works well in many cases. *)
     val guide : 'a I.symbol -> bool
+    
+    val use_indentation_heuristic : bool
   end
 
 module Make

--- a/src/driver.ml
+++ b/src/driver.ml
@@ -190,6 +190,8 @@ module R =
         default_value x
 
       let guide _ = false
+      
+      let use_indentation_heuristic = false
      end)
     (Merlin_recovery.DummyPrinter (I))
 


### PR DESCRIPTION
Problem: Last changes turn indentation heuristic on that negatively affects
recovery in some test cases

Solution: Make indentation heuristic optional. Indentation heuristic is
turned on by default