### PR TITLE
Improve report about costs

### DIFF
--- a/menhir-recover/attributes.ml
+++ b/menhir-recover/attributes.ml
@@ -253,14 +253,15 @@ struct
     )
 
   let cost_of_attributes prj attrs =
-    Cost.of_int (
-      List.fold_left
-        (fun total attr ->
-           if Attribute.has_label "recover.cost" attr then
-             total + int_of_string (Attribute.payload attr)
-           else total)
-        0 (prj attrs)
-    )
+    List.fold_left (fun total attr ->
+      if Attribute.has_label "recover.cost" attr then
+        let payload = Attribute.payload attr in
+        let cost = if payload =  "inf"
+                   then Cost.infinite
+                   else Cost.of_int (int_of_string payload)
+        in Cost.add total cost
+      else total)
+      Cost.zero (prj attrs)
 
   let cost_of_symbol =
     let measure ~has_default prj attrs =


### PR DESCRIPTION
# Make synthesis report more clear and self-contains.

## Problem 1: 
Currently it prints only the best solution and groups it by item (i.g. by
`(no_production, position_of_dot)`. It's incontinent when you are investigating
a specific decision of the algorithm in a specific state.

Solution: group solutions by states and print all potential solutions sorted by
cost

## Problem 2: 
Current report contains information only about solutions, but nothing
about how it comes. To reduce the requirement for source code knowledge (in some
cases handling recovery attributes is tricky) it would be better to make the
report more verbose.

Solution: print non-trivial cost of (non)terminal symbols, productions and items
penalty