### PR TITLE
fix opam package license

### DIFF
--- a/ocaml-recovery-parser.opam
+++ b/ocaml-recovery-parser.opam
@@ -8,7 +8,7 @@ version      : "0.1"
 synopsis     : "A simple fork of OCaml parser with support for error recovery"
 maintainer   : "Serokell"
 authors      : "Frédéric Bour"
-license      : "MIT and LGPL-2.1-only and MPL-2.0"
+license      : "MIT AND LGPL-2.1-only AND MPL-2.0"
 homepage     : "https://github.com/serokell/ocaml-recovery-parser"
 bug-reports  : "https://github.com/serokell/ocaml-recovery-parser/issues"
 # If you change the dependencies, run `opam lock` in the root


### PR DESCRIPTION
From commit message:

**fix opam package license**

Problem: when opam installs this package (e.g. from pin-dependency) it throws:
"warning 62: License doesn't adhere to the SPDX standard..."
The reason is that following SPDX standard (Annex SPDX License expression)
"operators (AND, OR, WITH) should be matched in case-sensitive manner"

Solution: fix case of and-operator in the opam file.