### PR TITLE
add $loc meta variable for `[@recover.expr` attribute

### DIFF
--- a/lib/merlin_recovery.ml
+++ b/lib/merlin_recovery.ml
@@ -76,7 +76,12 @@ module type RECOVERY_GENERATED =
   sig
     module I : MenhirLib.IncrementalEngine.EVERYTHING
 
-    val default_value : 'a I.symbol -> 'a
+    (* Note: [Location.t] is just default, but the type of the first argument
+             [loc] isn't restricted in the [RecoverParser] and can be inferred
+             from actual usage in attributes. In this case, you should shadow
+             this function your signature and convert your type into
+             [Location.t] in an implementation *)
+    val default_value : Custom_compiler_libs.Location.t -> 'a I.symbol -> 'a
 
     type action =
       | Abort
@@ -108,9 +113,6 @@ module type RECOVERY =
     include RECOVERY_GENERATED
 
     (* User customization functions *)
-
-    (* Like [RECOVERY_GENERATED.default], but also can use current parsing position. *)
-    val default_value : Custom_compiler_libs.Location.t -> 'a I.symbol -> 'a
 
     (* Customization that slightly affects on internal heuristics of choosing recovery ways.
        But returning [false] always also works well in many cases. *)

--- a/lib/merlin_recovery.mli
+++ b/lib/merlin_recovery.mli
@@ -44,7 +44,12 @@ module type RECOVERY_GENERATED =
   sig
     module I : MenhirLib.IncrementalEngine.EVERYTHING
 
-    val default_value : 'a I.symbol -> 'a
+    (* Note: [Location.t] is just default, but the type of the first argument
+             [loc] isn't restricted in the [RecoverParser] and can be inferred
+             from actual usage in attributes. In this case, you should shadow
+             this function your signature and convert your type into
+             [Location.t] in an implementation *)
+    val default_value : Custom_compiler_libs.Location.t -> 'a I.symbol -> 'a
 
     type action =
       | Abort
@@ -77,13 +82,10 @@ module type RECOVERY =
 
     (* User customization functions *)
 
-    (* Like [RECOVERY_GENERATED.default], but also can use current parsing position. *)
-    val default_value : Custom_compiler_libs.Location.t -> 'a I.symbol -> 'a
-
     (* Customization that slightly affects on internal heuristics of choosing recovery ways.
        But returning [false] always also works well in many cases. *)
     val guide : 'a I.symbol -> bool
-    
+
     val use_indentation_heuristic : bool
   end
 

--- a/menhir-recover/attributes.ml
+++ b/menhir-recover/attributes.ml
@@ -300,10 +300,16 @@ struct
           Format.fprintf ppf "%s\n" (Attribute.payload a)
       ) Grammar.attributes
 
+  (* Extract [@recover.expr] payload from list of attributes  *)
   let default_expr ?(fallback="raise Not_found") attrs =
+    (* Read [@recover.expr] payload *)
+    let read attr =
+      let expand = Str.global_replace (Str.regexp "\\$loc") "loc"
+      in expand (Attribute.payload attr)
+    in
     match List.find (Attribute.has_label "recover.expr") attrs with
     | exception Not_found -> fallback
-    | attr -> Attribute.payload attr
+    | attr -> read attr
 
   let default_terminal t =
     match Terminal.kind t with

--- a/menhir-recover/dune
+++ b/menhir-recover/dune
@@ -7,4 +7,4 @@
 (executable
  (name main)
  (public_name menhir-recover)
- (libraries fix menhirLib menhirSdk))
+ (libraries fix menhirLib menhirSdk str))

--- a/menhir-recover/emitter.ml
+++ b/menhir-recover/emitter.ml
@@ -163,7 +163,8 @@ end = struct
     fprintf ppf "module Default = struct\n";
     A.default_prelude ppf;
 
-    fprintf ppf "  let value (type a) : a %s.symbol -> a = function\n" menhir;
+    (* Suppress unused [loc] variable warning because its using is up to the user *)
+    fprintf ppf "  let [@warning \"-27\"] value (type a) loc : a %s.symbol -> a = function\n" menhir;
     Terminal.iter (fun t ->
         match A.default_terminal t with
         | None -> ()


### PR DESCRIPTION
**Problem:** there are no ways to pass default location into payload of
`[@recover.expr` attribute except global reference. And in many cases we really
need this.

**Solution:** add `loc` argument to `Recover.Parser.default_value` function and
introduce `$loc` meta variable as the user-side access to it.

Example of usage: `%token A [@recover.expr mk_A $loc]`